### PR TITLE
[IMP] tier_validation: Instalación de módulos de validaciones de niveles de la OCA

### DIFF
--- a/purchase_tier_validation/__manifest__.py
+++ b/purchase_tier_validation/__manifest__.py
@@ -11,7 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
-    "auto_install": True, # TRESCLOUD: Util para instalación automática desde el autoinstaller
+    "auto_install": True,  # TRESCLOUD: Util para instalación automática desde el autoinstaller
     "depends": ["purchase", "base_tier_validation"],
     "data": ["views/purchase_order_view.xml"],
 }

--- a/purchase_tier_validation/__manifest__.py
+++ b/purchase_tier_validation/__manifest__.py
@@ -11,6 +11,7 @@
     "license": "AGPL-3",
     "application": False,
     "installable": True,
+    "auto_install": True, # TRESCLOUD: Util para instalación automática desde el autoinstaller
     "depends": ["purchase", "base_tier_validation"],
     "data": ["views/purchase_order_view.xml"],
 }


### PR DESCRIPTION
Se añade puchase_tier_validation para instalar el módulo puchase_tier_validation_rules que centraliza las validaciones de niveles de la OCA.

Tarea: [#9924](https://www.trescloud.com/web#id=9924&cids=1&menu_id=955&action=462&model=project.task&view_type=form)
